### PR TITLE
fix: change npm bin usage into npm root #34

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -5,17 +5,17 @@ set -e
 cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit 1
 
 # Install prettier
-if [ ! -f "$(npm bin)"/prettier ]; then
+if [ ! -f "$(npm root)"/.bin/prettier ]; then
   echo "::group::🔄 Running npm install to install prettier..."
   npm install
   echo "::endgroup::"
 fi
 
-if [ ! -f "$(npm bin)"/prettier ]; then
+if [ ! -f "$(npm root)"/.bin/prettier ]; then
   echo "❌ Unable to locate or install prettier. Did you provide a workdir which contains a valid package.json?"
   exit 1
 else
-  echo ℹ️ prettier version: "$("$(npm bin)"/prettier --version)"
+  echo ℹ️ prettier version: "$("$(npm root)"/.bin/prettier --version)"
 fi
 
 echo "::group::📝 Running prettier with reviewdog 🐶 ..."
@@ -24,7 +24,7 @@ export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 # if reporter is github-pr-review, run prettier in write mode and report code suggestions
 if [ "$INPUT_REPORTER" = "github-pr-review" ]; then
-  "$(npm bin)"/prettier --write "${INPUT_PRETTIER_FLAGS}" 2>&1 \
+  "$(npm root)"/.bin/prettier --write "${INPUT_PRETTIER_FLAGS}" 2>&1 \
   | reviewdog \
       -efm="%E[%trror] %f: %m (%l:%c)" \
       -efm="%C[error]%r" \
@@ -40,7 +40,7 @@ if [ "$INPUT_REPORTER" = "github-pr-review" ]; then
 else
   
   # shellcheck disable=SC2086
-  "$(npm bin)"/prettier --check "${INPUT_PRETTIER_FLAGS}"  2>&1 | sed --regexp-extended 's/(\[warn\].*)$/\1 File is not properly formatted./' \
+  "$(npm root)"/.bin/prettier --check "${INPUT_PRETTIER_FLAGS}"  2>&1 | sed --regexp-extended 's/(\[warn\].*)$/\1 File is not properly formatted./' \
   | reviewdog \
       -efm="%-G[warn] Code style issues found in the above file(s). Forgot to run Prettier%. File is not properly formatted." \
       -efm="[%tarn] %f %m" \


### PR DESCRIPTION
I have rolled a simple fix for #34 to remove usage of `npm bin` and instead use `npm root` with `.bin` appended.

It looks like a simple change, I have run it locally but not tested it through github actions.