### PR TITLE
chore(deps): update reviewdog to 0.21.0 and fix: add -fail-level and deprecate -fail-on-error

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,18 @@ inputs:
       Default is `added`.
     default: 'added'
     required: false
+  fail_level:
+    description: |
+      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      Possible values: [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
     description: |
+      Deprecated, use `fail_level` instead.
       Exit code for reviewdog when errors are found [true,false].
       Default is `false`.
+    deprecationMessage: Deprecated, use `fail_level` instead.
     default: 'false'
     required: false
   reviewdog_flags:

--- a/action.yml
+++ b/action.yml
@@ -66,7 +66,7 @@ runs:
   steps:
     - uses: reviewdog/action-setup@v1
       with:
-        reviewdog_version: v0.14.2
+        reviewdog_version: v0.21.0
     - run: $GITHUB_ACTION_PATH/script.sh
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -35,10 +35,18 @@ inputs:
       Default is `added`.
     default: 'added'
     required: false
+  fail_level:
+    description: |
+      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      Possible values: [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
     description: |
+      Deprecated, use `fail_level` instead.
       Exit code for reviewdog when errors are found [true,false].
       Default is `false`.
+    deprecationMessage: Deprecated, use `fail_level` instead.
     default: 'false'
     required: false
   reviewdog_flags:
@@ -75,6 +83,7 @@ runs:
         INPUT_LEVEL: ${{ inputs.level }}
         INPUT_REPORTER: ${{ inputs.reporter }}
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
+        INPUT_FAIL_LEVEL: ${{ inputs.fail_level }}
         INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
         INPUT_REVIEWDOG_FLAGS: ${{ inputs.reviewdog_flags }}
         INPUT_TOOL_NAME: ${{ inputs.tool_name }}
@@ -86,6 +95,7 @@ runs:
         tool_name: ${{ inputs.tool_name }}
         level: ${{ inputs.level }}
         filter_mode: ${{ inputs.filter_mode }}
+        fail_level: ${{ inputs.fail_level }}
         fail_on_error: ${{ inputs.fail_on_error }}
         reviewdog_flags: ${{ inputs.reviewdog_flags }}
 

--- a/script.sh
+++ b/script.sh
@@ -33,6 +33,7 @@ if [ "$INPUT_REPORTER" = "github-pr-review" ]; then
       -name="${INPUT_TOOL_NAME}" \
       -reporter="${INPUT_REPORTER}" \
       -filter-mode="${INPUT_FILTER_MODE}" \
+      -fail-level=${INPUT_FAIL_LEVEL} \
       -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
       -level="${INPUT_LEVEL}" \
       "${INPUT_REVIEWDOG_FLAGS}"
@@ -51,6 +52,7 @@ else
       -name="${INPUT_TOOL_NAME}" \
       -reporter="${INPUT_REPORTER}" \
       -filter-mode="${INPUT_FILTER_MODE}" \
+      -fail-level=${INPUT_FAIL_LEVEL} \
       -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
       -level="${INPUT_LEVEL}" \
       "${INPUT_REVIEWDOG_FLAGS}"


### PR DESCRIPTION
Supersedes https://github.com/EPMatt/reviewdog-action-prettier/pull/52 and https://github.com/EPMatt/reviewdog-action-prettier/pull/71.

Fixes https://github.com/EPMatt/reviewdog-action-prettier/issues/72.
Fixes https://github.com/EPMatt/reviewdog-action-prettier/issues/67.

@EPMatt 